### PR TITLE
Auto-detection of the serial board added.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,12 +26,9 @@ io.on('connection', function(socket){
 // Arduino settings.
 const MAX_VOLTAGE = 5.0;
 const ANALOG_PIN = 6;
-const COM_PORT = "Com6";
 var voltage_value = 0;
 
-var board = new five.Board({
-    port: COM_PORT
-});
+var board = new five.Board();
 
 // Sends voltage value to websocket webpage
 io.on('connection', function(){


### PR DESCRIPTION
Previous version set up a port to COM6. This was done while connecting the Arduino to the same port. There were issues in detecting while the COM port for Bluetooth were ON. I disabled the Bluetooth on my computer. The code detects the COM Port automatically when Bluetooth is OFF.

This is not a major change, however, it makes sense to give the user the flexibility to using other ports. This also removes the restriction of sticking to the same Port if it does not exists on the machine.